### PR TITLE
jajg/FIX-fallback-function-for-random-api creating fallback function …

### DIFF
--- a/app/api/game_routes.py
+++ b/app/api/game_routes.py
@@ -4,6 +4,7 @@ import requests
 import uuid
 from ..rate_limiter import limiter
 from ..utils.responses import success_response, error_response
+from ..utils.generate_local_sequence import generate_local_sequence
 
 from ..utils.get_hint import get_hint
 
@@ -16,10 +17,11 @@ game_routes = Blueprint("game", __name__)
 game_states = {}
 
 def fetch_random_sequence(difficulty):
-    """Fetches a random sequence from Random.org based on difficulty."""
+    """Fetches a random sequence from Random.org based on difficulty.
+    Falls back to local generation if the API fails"""
     if difficulty not in ALLOWED_DIFFICULTIES:
         # Early return if invalid difficulty
-        return None, "Invalid difficulty level."
+        return None, False, "Invalid difficulty level."
 
     # Select the appropriate URL based on difficulty
     url = BASE_URL_MEDIUM if difficulty == "medium" else BASE_URL_HARD
@@ -31,32 +33,44 @@ def fetch_random_sequence(difficulty):
 
         expected_length = 4 if difficulty == "medium" else 6
         if len(data) != expected_length or any(not line.isdigit() for line in data):
-            return None, "Invalid data received from the random number generator."
+            return None, False, "Invalid data received from the random number generator."
 
         sequence = "".join(data)
-        return sequence, None
+        return sequence, False, None
     except requests.exceptions.RequestException as error:
-        return None, str(error)
+        response = generate_local_sequence(4 if difficulty == "medium" else 6)
+        data = response.split()
+        sequence = "".join(data)
+        return sequence, True, "Random.org API failed. Generated sequence locally."
 
 # 5 games per minute per IP address
 # https://medium.com/analytics-vidhya/how-to-rate-limit-routes-in-flask-61c6c791961b#:~:text=In%20flask%20there%20is%20a,track%20of%20their%20IP%20address.
 @game_routes.route("/start/<string:difficulty>", methods=["GET"])
 @limiter.limit("5 per minute")
 def start_game(difficulty):
-    sequence, err = fetch_random_sequence(difficulty)
-    if err:
-        return error_response(err, 400 if "Invalid difficulty" in err else 500)
-
+    sequence, fallback_used, err = fetch_random_sequence(difficulty)
+    
+    if err and not fallback_used:
+        return error_response(err)
+    
     game_id = str(uuid.uuid4())
     game_states[game_id] = {
         "solution": sequence,
         "attempts_left": 10,
         "status": "ongoing"
     }
+    
+    if err:
+        return success_response({
+            "game_id": game_id,
+            "length": len(sequence),
+            "is_sequence_locally_generated": fallback_used
+        })
 
     return success_response({
         "game_id": game_id,
-        "length": len(sequence)
+        "length": len(sequence),
+        "is_sequence_locally_generated": fallback_used
     })
         
 
@@ -90,39 +104,35 @@ def make_guess():
         
         correct_positions, correct_numbers_only = hints 
         attempts_left -= 1
+        
+        response_data = {
+                        "correct_positions": correct_positions,
+                        "correct_numbers_only": correct_numbers_only,
+                        "attempts_left": attempts_left,
+                        "status": "ongoing"  # could be "win", "lose", or "ongoing"
+                    }
 
         # Check if all of the positions and numbers are correct!
         if correct_positions == len(sequence):
             current_game["status"] = "win"
             current_game["attempts_left"] = attempts_left
-            return success_response({
-                        "correct_positions": correct_positions,
-                        "correct_numbers_only": correct_numbers_only,
-                        "attempts_left": attempts_left,
-                        "status": "win"  # could be "win", "lose", or "ongoing"
-                    })
+            response_data["status"] = "win"
+            response_data["solution"] = sequence
+            return success_response(response_data)
             
         # If not all but guess attempts_left is 0 then you lose!
         if correct_positions != len(sequence) and attempts_left == 0:
             current_game["status"] = "lose"
             current_game["attempts_left"] = attempts_left
-            return success_response({
-                        "correct_positions": correct_positions,
-                        "correct_numbers_only": correct_numbers_only,
-                        "attempts_left": attempts_left,
-                        "status": "lose"  # could be "win", "lose", or "ongoing"
-                    })
+            response_data["status"] = "lose"
+            response_data["solution"] = sequence
+            return success_response(response_data)
                 
         
         # The game is yet to finish
         current_game["attempts_left"] = attempts_left
         
-        return success_response({
-                    "correct_positions": correct_positions,
-                    "correct_numbers_only": correct_numbers_only,
-                    "attempts_left": attempts_left,
-                    "status": "ongoing"  # could be "win", "lose", or "ongoing"
-                })
+        return success_response(response_data)
             
         
     except Exception as error:

--- a/app/tests/test_routes.py
+++ b/app/tests/test_routes.py
@@ -2,6 +2,7 @@ import pytest
 from app.api.game_routes import game_routes, game_states
 from flask import Flask
 import requests_mock
+from unittest.mock import patch
 
 BASE_URL_MEDIUM = "https://www.random.org/integers/?num=4&min=0&max=7&col=1&base=10&format=plain&rnd=new"
 BASE_URL_HARD = "https://www.random.org/integers/?num=6&min=0&max=7&col=1&base=10&format=plain&rnd=new"
@@ -26,6 +27,8 @@ def test_start_game_medium(client, requests_mock):
     # JSON = {data: [{}], error: None}
     assert "game_id" in json_data["data"][0]
     assert "length" in json_data["data"][0]
+    assert "is_sequence_locally_generated" in json_data["data"][0]
+    assert json_data["data"][0]["is_sequence_locally_generated"] == False
     game_id = json_data["data"][0]["game_id"]
     length = json_data["data"][0]["length"]
     assert game_id in game_states
@@ -47,6 +50,8 @@ def test_start_game_hard(client, requests_mock):
     # JSON = {data: [{}], error: None}
     assert "game_id" in json_data["data"][0]
     assert "length" in json_data["data"][0]
+    assert "is_sequence_locally_generated" in json_data["data"][0]
+    assert json_data["data"][0]["is_sequence_locally_generated"] == False
     game_id = json_data["data"][0]["game_id"]
     length = json_data["data"][0]["length"]
     assert game_id in game_states
@@ -83,6 +88,7 @@ def test_make_guess_win_medium(client, requests_mock):
     assert json_data["data"][0]["correct_positions"] == 4
     assert json_data["data"][0]["correct_numbers_only"] == 0
     assert json_data["data"][0]["attempts_left"] == 9
+    assert json_data["data"][0]["solution"] == "1234"
     
 def test_make_guess_win_hard(client, requests_mock):
     mock_data = "0\n1\n2\n3\n4\n5"
@@ -103,6 +109,7 @@ def test_make_guess_win_hard(client, requests_mock):
     assert json_data["data"][0]["correct_positions"] == 6
     assert json_data["data"][0]["correct_numbers_only"] == 0
     assert json_data["data"][0]["attempts_left"] == 9
+    assert json_data["data"][0]["solution"] == "012345"
 
 def test_make_guess_lose_medium(client, requests_mock):
     mock_data = "1\n2\n3\n4"
@@ -120,6 +127,11 @@ def test_make_guess_lose_medium(client, requests_mock):
         json_data = response.get_json()
         assert json_data["data"][0]["status"] == ("lose" if i == 9 else "ongoing")
         assert json_data["data"][0]["attempts_left"] == (9 - i)
+        if i < 9:
+            assert "solution" not in json_data["data"][0]
+        else:
+            assert "solution" in json_data["data"][0]
+            assert json_data["data"][0]["solution"] == "1234"
         
 def test_make_guess_lose_hard(client, requests_mock):
     mock_data = "0\n1\n2\n3\n4\n5"
@@ -137,6 +149,11 @@ def test_make_guess_lose_hard(client, requests_mock):
         json_data = response.get_json()
         assert json_data["data"][0]["status"] == ("lose" if i == 9 else "ongoing")
         assert json_data["data"][0]["attempts_left"] == (9 - i)
+        if i < 9:
+            assert "solution" not in json_data["data"][0]
+        else:
+            assert "solution" in json_data["data"][0]
+            assert json_data["data"][0]["solution"] == "012345"
 
 def test_make_guess_after_win(client, requests_mock):
     """Test making a guess after the game has been won."""
@@ -260,3 +277,105 @@ def test_make_guess_non_digit_guess(client, requests_mock):
     assert response.status_code == 400
     assert json_data["data"] == []
     assert json_data["error"] == "Guess must be a 4-digit string."
+
+def test_start_game_medium_fallback(client, requests_mock):
+    """Test starting a medium difficulty game when Random.org API fails, triggering fallback."""
+    # Simulate API failure. This is to test the utils/generate_local_sequence function
+    requests_mock.get(BASE_URL_MEDIUM, status_code=503)
+
+    # config = {'method.return_value': 3, 'other.side_effect': KeyError}
+    
+    # Mocking the response returned by the function in the context of the API rather than where it was defined
+    with patch("app.api.game_routes.generate_local_sequence", return_value="0\n1\n2\n3"):
+        response = client.get("/api/game/start/medium")
+        json_data = response.get_json()
+
+        assert response.status_code == 200
+        # JSON = {data: [{}], error: None}
+        assert "game_id" in json_data["data"][0]
+        assert "length" in json_data["data"][0]
+        assert "is_sequence_locally_generated" in json_data["data"][0]
+        assert json_data["data"][0]["is_sequence_locally_generated"] == True
+
+        game_id = json_data["data"][0]["game_id"]
+        length = json_data["data"][0]["length"]
+        assert game_id in game_states
+        assert length == 4
+        assert game_states[game_id]["solution"] == "0123"
+        assert len(game_states[game_id]["solution"]) == 4
+        assert game_states[game_id]["status"] == "ongoing"
+        assert game_states[game_id]["attempts_left"] == 10
+
+def test_start_game_hard_fallback(client, requests_mock):
+    """Test starting a hard difficulty game when Random.org API fails, triggering fallback."""
+    # Simulate API failure
+    requests_mock.get(BASE_URL_HARD, status_code=503)
+
+    with patch("app.api.game_routes.generate_local_sequence", return_value="0\n1\n2\n3\n4\n5"):
+        response = client.get("/api/game/start/hard")
+        json_data = response.get_json()
+
+        assert response.status_code == 200
+        # JSON = {data: [{}], error: None}
+        assert "game_id" in json_data["data"][0]
+        assert "length" in json_data["data"][0]
+        assert "is_sequence_locally_generated" in json_data["data"][0]
+        assert json_data["data"][0]["is_sequence_locally_generated"] == True
+
+        game_id = json_data["data"][0]["game_id"]
+        length = json_data["data"][0]["length"]
+        assert game_id in game_states
+        assert length == 6
+        assert game_states[game_id]["solution"] == "012345" 
+        assert len(game_states[game_id]["solution"]) == 6
+        assert game_states[game_id]["status"] == "ongoing"
+        assert game_states[game_id]["attempts_left"] == 10
+
+# Resource for mocking my endpoint which calls a function to generate it in case the third party API fails: 
+# https://stackoverflow.com/questions/53590758/how-to-mock-function-call-in-flask-restul-resource-method
+def test_make_guess_with_fallback_sequence_revealed_on_win(client, requests_mock):
+    """Test that when a game started with a fallback, the solution is revealed upon winning."""
+    # Simulate API failure
+    requests_mock.get(BASE_URL_MEDIUM, status_code=503)
+
+    with patch("app.api.game_routes.generate_local_sequence", return_value="0\n1\n2\n3"):
+        start_response = client.get("/api/game/start/medium")
+        game_id = start_response.get_json()["data"][0]["game_id"]
+
+        # Simulate a winning guess
+        response = client.post("/api/game/guess", json={
+            "game_id": game_id,
+            "guess": "0123"
+        })
+        json_data = response.get_json()
+
+        assert response.status_code == 200
+        assert json_data["data"][0]["status"] == "win"
+        assert json_data["data"][0]["correct_positions"] == 4
+        assert json_data["data"][0]["correct_numbers_only"] == 0
+        assert json_data["data"][0]["attempts_left"] == 9
+        assert json_data["data"][0]["solution"] == "0123"
+
+def test_make_guess_with_fallback_sequence_revealed_on_lose(client, requests_mock):
+    """Test that when a game started with a fallback, the solution is revealed upon losing."""
+    # Simulate API failure
+    requests_mock.get(BASE_URL_MEDIUM, status_code=503)
+    
+    with patch("app.api.game_routes.generate_local_sequence", return_value="0\n1\n2\n3"):
+        start_response = client.get("/api/game/start/medium")
+        game_id = start_response.get_json()["data"][0]["game_id"]
+
+        # Simulate losing by exhausting the 10 attempts
+        for i in range(10):
+            response = client.post("/api/game/guess", json={
+                "game_id": game_id,
+                "guess": "5678"  # Incorrect guess
+            })
+            json_data = response.get_json()
+            assert json_data["data"][0]["status"] == ("lose" if i == 9 else "ongoing")
+            assert json_data["data"][0]["attempts_left"] == (9 - i)
+            if i < 9:
+                assert "solution" not in json_data["data"][0]
+            else:
+                assert "solution" in json_data["data"][0]
+                assert json_data["data"][0]["solution"] == "0123"

--- a/app/utils/generate_local_sequence.py
+++ b/app/utils/generate_local_sequence.py
@@ -1,0 +1,6 @@
+import random
+
+def generate_local_sequence(num, min_val=0, max_val=7):
+    """Generates a local random sequence given a num length and a range of numbers."""
+    return "\n".join(str(random.randint(min_val, max_val)) for _ in range(num))
+    


### PR DESCRIPTION
…so that the app continues to generate a random sequence even if the third party API is down.

### Description

Please include a summary of the change and which issue is addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

A fallback function was created and tested so that if the random.org API is down we can rely on this other function to generate a sequence making the service more reliable. In an attempt to, in the future, add analytics and a Health Service our API is now returning whether the fallback generated the sequence(something that is only done if the random.org API is down). So, once that Health service is implemented, if the number of logs show that the number of fallback generated sequences is too high we might have to consider other alternative API's to generate such sequence or simple rely in our function.

Fixes #(issue)

https://github.com/JeffersonGarcia15/Mastermind/issues/5

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [x] Manual Testing
- [x] Unit test: pytest
- [ ] e2e: Playwright

### How to use the feature

A GIF of the feature in action is useful here for larger features, otherwise a description suffices.

Simply run the tests using `pytest tests`

### Prerequisites

Whether reviewers should add env variables (don't put them in here), run npm install, specific browser requirements, etc.
 N/A. 

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have linked the relevant issue(s) to this PR
- [ ] All checks pass on CI/CD.
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
